### PR TITLE
SaltListner will now crash when the connection is lost

### DIFF
--- a/salt/salt_listener.py
+++ b/salt/salt_listener.py
@@ -8,7 +8,11 @@ class SaltListener:
     def __init__(self, timeout=None):
         opts = salt.config.client_config(ETC_SALT_MASTER)
         self.listener = salt.utils.event.get_event(
-            "master", sock_dir=opts["sock_dir"], transport=opts["transport"], opts=opts
+            "master",
+            sock_dir=opts["sock_dir"],
+            transport=opts["transport"],
+            opts=opts,
+            raise_errors=True,
         )
         if timeout is None:
             self.timeout_secs = 0


### PR DESCRIPTION
`SaltListener` will now error when the stream is closed, salt-master restarts.
Then systemd will restart the service and it will connect to the new salt-master.
